### PR TITLE
Don’t pass deployMode and spark.master when launching a driver.

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -424,7 +424,9 @@ private[spark] class MesosClusterScheduler(
       "--driver-memory", s"${desc.mem}M")
 
     val replicatedOptionsBlacklist = Set(
-      "spark.jars" // Avoids duplicate classes in classpath
+      "spark.jars", // Avoids duplicate classes in classpath
+      "spark.submit.deployMode", // this would be set to `cluster`, but we need client
+      "spark.master" // this contains the address of the dispatcher, not master
     )
 
     // Assume empty main class means we're running python


### PR DESCRIPTION
- the launched driver should be in client mode, but at submission time this setting is set to ‘cluster’.
- the `spark.master` setting is set to the dispatcher address (usually on port 7077). Passing it has no effect,
  since we also pass `—-master` which takes precedence. But this is confusing so we should filter it out.
